### PR TITLE
Fix issues on iOS 13

### DIFF
--- a/ACFloatingInput/Source/Extensions/UIImage+ACFloatingInput.h
+++ b/ACFloatingInput/Source/Extensions/UIImage+ACFloatingInput.h
@@ -10,6 +10,6 @@
 
 @interface UIImage (ACFloatingInput)
 
-- (UIImage *) imageWithTintColor:(UIColor *)color;
+- (UIImage *) imageBySettingTintColor:(UIColor *)color;
 
 @end

--- a/ACFloatingInput/Source/Extensions/UIImage+ACFloatingInput.m
+++ b/ACFloatingInput/Source/Extensions/UIImage+ACFloatingInput.m
@@ -10,7 +10,7 @@
 
 @implementation UIImage (ACFloatingInput)
 
-- (UIImage *) imageWithTintColor:(UIColor *)color {
+- (UIImage *) imageBySettingTintColor:(UIColor *)color {
     
     CGRect rect = CGRectMake(0, 0, self.size.width, self.size.height);
     UIGraphicsBeginImageContextWithOptions(rect.size, NO, self.scale);

--- a/ACFloatingInput/Source/Views/ACFloatingInput.m
+++ b/ACFloatingInput/Source/Views/ACFloatingInput.m
@@ -1137,8 +1137,8 @@
             UIImage *image = [UIImage imageNamed:@"input_preview_password_icon"];
             
             UIButton *button = [[UIButton alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 25.0f, 35.0f)];
-            [button setImage:[image imageWithTintColor:self.deselectedColor] forState:UIControlStateNormal];
-            [button setImage:[image imageWithTintColor:self.selectedColor] forState:UIControlStateSelected];
+            [button setImage:[image imageBySettingTintColor:self.deselectedColor] forState:UIControlStateNormal];
+            [button setImage:[image imageBySettingTintColor:self.selectedColor] forState:UIControlStateSelected];
             [button addTarget:self action:@selector(changeSecureTextEntry:) forControlEvents:UIControlEventTouchUpInside];
             [button.imageView setContentMode:UIViewContentModeScaleAspectFit];
             
@@ -1152,13 +1152,15 @@
         }
         case ACFloatingInputTypeSelection: {
             
+            UIView *rightView = [[UIView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 15.0f, 15.0f)];
             UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 15.0f, 15.0f)];
             imageView.image = [UIImage imageNamed:@"arrow_down_icon"];
+            [rightView addSubview:imageView];
             
             ACTextField *textField = [[ACTextField alloc] init];
             textField.rightViewMode = UITextFieldViewModeAlways;
             textField.userInteractionEnabled = NO;
-            textField.rightView = imageView;
+            textField.rightView = rightView;
             
             inputView = textField;
             break;


### PR DESCRIPTION
1. Rename method imageWithTintColor --> imageBySettingTintColor, to avoid conflict with new UIKit method in UIImage.
2. Wrap arrow image view in container view  for input of type ACFloatingInputTypeSelection in order to fix size issue.